### PR TITLE
Fix duplicates jobs in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
 workflows:
   ci-build:
     jobs:
-    - testy:
+    - test:
         filters:
           branches:
             ignore: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,10 @@ jobs:
 workflows:
   ci-build:
     jobs:
-    - test
+    - testy:
+        filters:
+          branches:
+            ignore: master
     - lumigo-orb/be-deploy:
         filters:
           branches:


### PR DESCRIPTION
This is what happens now on merge to Master:
![image](https://user-images.githubusercontent.com/49228804/160279363-10455b66-8635-4567-b0f1-f7d187235b6e.png)

We don't need that "test" will run more than once so I'm cancelling "ci-build/test" on Master.